### PR TITLE
Nix x IPFS: fix URL

### DIFF
--- a/open-grants/open-proposal-nix-ipfs.md
+++ b/open-grants/open-proposal-nix-ipfs.md
@@ -255,7 +255,7 @@ As an interested party, Obsidian Systems will contribute funding to this grant i
 
 ## Maintenance and Upgrade Plans
 
-We will upstream all changes to Nix, breaking out changes into PRs and writing [RFCs](github.com/nixos/rfcs) as needed.
+We will upstream all changes to Nix, breaking out changes into PRs and writing [RFCs](https://github.com/nixos/rfcs) as needed.
 
 Changes may be requested during the RFC process, in which case we will make those changes, but we do not expect outright rejection as we think these features will be extremely popular.
 


### PR DESCRIPTION
It's treated as a relative URL without the protocol, so add that.

---

I was reading the proposal as an interested third party and tried to follow the link to Nix's RFCs, but noticed it went to the wrong place (specifically, it linked to https://github.com/ipfs/devgrants/blob/f624cebe170a3743cc9ed254c483dcc079e16bb6/open-grants/github.com/nixos/rfcs).