### PR TITLE
Reopen grants

### DIFF
--- a/.github/ISSUE_TEMPLATE/microgrant.md
+++ b/.github/ISSUE_TEMPLATE/microgrant.md
@@ -7,11 +7,15 @@ assignees: mishmosh
 ---
 
 ### 1. What is your project? (max 100 words)
-<!-- link and description of your project built with IPFS or closely related technologies (libp2p, ipld, etc.) -->
+<!-- Description of your project built with IPFS or closely related technologies (libp2p, ipld, OrbitDB, Textile, etc.) -->
+
+<!-- Link to Github repo -->
+  
+<!-- Link to demo or website, if applicable -->
 
 ### 2. How are you planning to improve this project? (max 200 words)
-<!-- clear and concise description of the planned next step(s) or improvements for which you are seeking grant support -->
-
+<!-- Clear and concise description of the planned next step(s) or improvements for which you are seeking grant support -->
+ 
 ### 3. Will the work be Open Source?
 <!-- MIT license for code or [CC-BY-SA 3.0](https://ipfs.io/ipfs/QmVreNvKsQmQZ83T86cWSjPu2vR3yZHGPm5jnxFuunEB9u) license for content. -->
 
@@ -21,6 +25,20 @@ assignees: mishmosh
 ### 5. Does your proposal comply with our Community Standards?
 <!-- Please read the [Community Standards](https://github.com/protocol/ipfs-grants/blob/master/STANDARDS.md) and make sure your project is in compliance -->
 
-### Informational questions:
-* Any additional websites, CVs, Github profiles, or personal links you'd like to share?
-* Was your project created independently, or part of a training course or hackathon?
+### 6. Links and submissions
+<!-- Complete each step, and include the link of the published submission (or "Yes" if there is no URL) -->
+  
+* Have you submitted to the IPFS Community Showcase ([instructions](https://github.com/ipfs/community/blob/master/README.md#showcase-your-project))?
+  <!-- Once your PR is merged, include the link here -->
+
+* Have you added your project to the [IPFS Ecosystem Directory](https://airtable.com/shrjwvk9pAeAk0Ci7)? <!-- Submit the form, then change this text to "Yes" -->
+  
+* If your project began at a hackathon, have you submitted it for the relevant Protocol Labs prizes? Include links here if available:
+  
+* Have you filled out the [Interplanetary Builder Feedback Survey](https://airtable.com/shrDZMizx03jOa4mQ)? 
+  
+### Additional questions:
+* For each team member(s), please list name, email, Github account, and role in the project.
+* If your project was created as part of an event or hackathon:
+  * What was the name of the event? (e.g. ETHGlobal NFTHack, Cal Hacks hello:world, Chainlink, CivHacks, GameDevJ, ETHGlobal Scaling Ethereum)
+  * Please link to your hackathon submission, proving you're a team that submitted for a Protocol Labs prize.

--- a/.github/ISSUE_TEMPLATE/microgrant.md
+++ b/.github/ISSUE_TEMPLATE/microgrant.md
@@ -1,23 +1,26 @@
 ---
-name: Microgrant Application 
-about: Adoption Microgrant Program ⚠️ on hold until Q1 2021 ⚠️
-title: 'Microgrant: <Your Title Here>'
-labels: type:microgrant
+name: Next Step Microgrant Application 
+about: Submit this issue to apply for a Next Step Microgrant
+title: 'Next Step Microgrant: <Your Title Here>'
+labels: type:nextstep
 assignees: parkan
-
 ---
 
-### What do you work on? (max 100 words)
-<!-- a description of your professional, academic, artistic or other work -->
+### 1. What is your project? (max 100 words)
+<!-- link and description of your project built with IPFS or closely related technologies (libp2p, ipld, etc.) -->
 
-### How are you planning to incorporate IPFS into your work? (max 250 words)
-<!-- detailed but concise description of your planned IPFS integration -->
+### 2. How are you planning to improve this project? (max 200 words)
+<!-- clear and concise description of the planned next step(s) or improvements for which you are seeking grant support -->/
 
-### Website(s) (CV, GitHub, personal page...)
-<!-- https://your-website-here -->
+### 3. Will the work be Open Source?
+<!-- MIT license for code or [CC-BY-SA 3.0](https://ipfs.io/ipfs/QmVreNvKsQmQZ83T86cWSjPu2vR3yZHGPm5jnxFuunEB9u) license for content. -->
 
-### Will the work be Open Source? (if not, explain why)
-<!-- code licensed under any [OSI-approved](https://opensource.org/licenses) license and made available publicly -->
+### 4. If selected, do you agree to complete a grant report one month after award date?
+<!-- We will provide an issue template wuth prompts for the results of your microgrant-funded work, as well as a description of your experience building on IPFS, including any challenges or shortcomings encountered. -->
+  
+### 5. Does your proposal comply with our Community Standards?
+<!-- Please read the [Community Standards](https://github.com/protocol/ipfs-grants/blob/master/STANDARDS.md) and make sure your project is in compliance -->
 
-### Does your proposal comply with our Community Standards?
-<!-- please read the [Community Standards](https://github.com/protocol/ipfs-grants/blob/master/STANDARDS.md) and make sure your project is in compliance -->
+### Informational questions:
+* Any additional websites, CVs, Github profiles, or personal links you'd like to share?
+* Was your project created independently, or part of a training course or hackathon?

--- a/.github/ISSUE_TEMPLATE/microgrant.md
+++ b/.github/ISSUE_TEMPLATE/microgrant.md
@@ -2,8 +2,8 @@
 name: Next Step Microgrant Application 
 about: Submit this issue to apply for a Next Step Microgrant
 title: 'Next Step Microgrant: <Your Title Here>'
-labels: type:nextstep
-assignees: parkan
+labels: type:microgrant
+assignees: mishmosh
 ---
 
 ### 1. What is your project? (max 100 words)

--- a/.github/ISSUE_TEMPLATE/microgrant.md
+++ b/.github/ISSUE_TEMPLATE/microgrant.md
@@ -10,7 +10,7 @@ assignees: parkan
 <!-- link and description of your project built with IPFS or closely related technologies (libp2p, ipld, etc.) -->
 
 ### 2. How are you planning to improve this project? (max 200 words)
-<!-- clear and concise description of the planned next step(s) or improvements for which you are seeking grant support -->/
+<!-- clear and concise description of the planned next step(s) or improvements for which you are seeking grant support -->
 
 ### 3. Will the work be Open Source?
 <!-- MIT license for code or [CC-BY-SA 3.0](https://ipfs.io/ipfs/QmVreNvKsQmQZ83T86cWSjPu2vR3yZHGPm5jnxFuunEB9u) license for content. -->

--- a/.github/ISSUE_TEMPLATE/microgrant.md
+++ b/.github/ISSUE_TEMPLATE/microgrant.md
@@ -16,7 +16,7 @@ assignees: mishmosh
 <!-- MIT license for code or [CC-BY-SA 3.0](https://ipfs.io/ipfs/QmVreNvKsQmQZ83T86cWSjPu2vR3yZHGPm5jnxFuunEB9u) license for content. -->
 
 ### 4. If selected, do you agree to complete weekly updates and a grant report upon conclusion?
-<!-- We will provide a discussion forum link the results of your microgrant-funded work, as well as a description of your experience building on IPFS, including any challenges or shortcomings encountered. -->
+<!-- Include progress or results of your microgrant-funded work, any IPFS technical or usage guidance requests, and a description of your experience building on IPFS, including any challenges or shortcomings encountered. -->
   
 ### 5. Does your proposal comply with our Community Standards?
 <!-- Please read the [Community Standards](https://github.com/protocol/ipfs-grants/blob/master/STANDARDS.md) and make sure your project is in compliance -->

--- a/.github/ISSUE_TEMPLATE/microgrant.md
+++ b/.github/ISSUE_TEMPLATE/microgrant.md
@@ -15,8 +15,8 @@ assignees: mishmosh
 ### 3. Will the work be Open Source?
 <!-- MIT license for code or [CC-BY-SA 3.0](https://ipfs.io/ipfs/QmVreNvKsQmQZ83T86cWSjPu2vR3yZHGPm5jnxFuunEB9u) license for content. -->
 
-### 4. If selected, do you agree to complete a grant report one month after award date?
-<!-- We will provide an issue template wuth prompts for the results of your microgrant-funded work, as well as a description of your experience building on IPFS, including any challenges or shortcomings encountered. -->
+### 4. If selected, do you agree to complete weekly updates and a grant report upon conclusion?
+<!-- We will provide a discussion forum link the results of your microgrant-funded work, as well as a description of your experience building on IPFS, including any challenges or shortcomings encountered. -->
   
 ### 5. Does your proposal comply with our Community Standards?
 <!-- Please read the [Community Standards](https://github.com/protocol/ipfs-grants/blob/master/STANDARDS.md) and make sure your project is in compliance -->

--- a/MICROGRANTS.md
+++ b/MICROGRANTS.md
@@ -29,7 +29,10 @@ Grant applications are typically reviewed every 2 weeks.
 
 ## Apply
 
-[**Apply Here**](https://github.com/protocol/ipfs-grants/issues/new?assignees=parkan&labels=microgrant&template=microgrant.md&title=%5BMICROGRANT%5D+%3CYour+Title+Here%3E)
+1. Add your project to the IPFS Community Showcase by following the instructions in [ipfs/community](https://github.com/ipfs/community/blob/master/README.md#ecosystem-projects).
+2. Register your project for the [IPFS ecosystem database](https://airtable.com/shrjwvk9pAeAk0Ci7).
+3. Fill out this [VERY SHORT survey](https://airtable.com/shrDZMizx03jOa4mQ) about your experience building on IPFS.
+4. ONLY once your ipfs/community PR has been merged, [**APPLY HERE**](https://github.com/protocol/ipfs-grants/issues/new?assignees=mishmosh&labels=microgrant&template=microgrant.md&title=%5BMICROGRANT%5D+%3CYour+Title+Here%3E)
 
 ## FAQ
 

--- a/MICROGRANTS.md
+++ b/MICROGRANTS.md
@@ -10,21 +10,21 @@ From time-to-time, we may announce a [focus area](FOCUS.md) (such as offline use
 These grants are intended for independent developers, small studios, non-profits, activists, researchers... and you! 
 
 ### Award
-Next Step Microgrants are awarded in the amount of **$5,000**. The entire grant amount be used to support work related to integrating or improving IPFS, such as developer time, hosting services, relevant hardware such as a raspberry pi, etc. 
+Next Step Microgrants are awarded in the amount of **$5,000**, paid in FIL tokens. The entire grant amount be used to support work related to integrating or improving IPFS, such as developer time, hosting services, relevant hardware such as a raspberry pi, etc. 
 
 ### Applying and Reporting
 Next Step Microgrants are intended to be easy to apply for, evaluate, and administer. Projects must meet these 5 criteria:
 
 1. You've already built something with IPFS (or closely related technologies such as IPLD, libp2p, etc.), independently or as part of a course or hackathon.
 1. You can provide a clear and straightforward description of the _Next Step_ you plan to take with grant support.
-1. You can complete this work within 1 month. 
+1. You can complete this work within 3 months. 
 1. You agree to open-source this work, via MIT license for code or [CC-BY-SA 3.0](https://ipfs.io/ipfs/QmVreNvKsQmQZ83T86cWSjPu2vR3yZHGPm5jnxFuunEB9u) license for content.
-1. You agree to complete a grant report 1 month after award date, with the results of your microgrant-funded work, as well as a description of your experience building on IPFS, including any challenges or shortcomings encountered.
+1. You agree to complete weekly updates and a grant report upon conclusion, with the results of your microgrant-funded work as well as a description of your experience building on IPFS, including any challenges or shortcomings encountered.
 
 We may also contact you about promoting the resulting work, including coverage on [the IPFS Blog](https://blog.ipfs.io/) or social media.
 
 ### Timelines
-Applications are reviewed every 2 weeks. The next 2 review dates are June 1 and June 15, 2021.
+Grant applications are typically reviewed every 2 weeks.
 
 ## Apply
 

--- a/MICROGRANTS.md
+++ b/MICROGRANTS.md
@@ -1,3 +1,4 @@
+
 # Next Step Microgrants
 
 ## About
@@ -12,10 +13,10 @@ These grants are intended for independent developers, small studios, non-profits
 ### Award
 Next Step Microgrants are awarded in the amount of **$5,000**, paid in FIL tokens. The entire grant amount be used to support work related to integrating or improving IPFS, such as developer time, hosting services, relevant hardware such as a raspberry pi, etc. 
 
-### Applying and Reporting
+### Program Qualifications
 Next Step Microgrants are intended to be easy to apply for, evaluate, and administer. Projects must meet these 5 criteria:
 
-1. You've already built something with IPFS (or closely related technologies such as IPLD, libp2p, etc.), independently or as part of a course or hackathon.
+1. You've already built something with IPFS (or closely related technologies such as IPLD, libp2p, or frameworks such as OrbitDB, Textile, etc.), independently or as part of a course or hackathon.
 1. You can provide a clear and straightforward description of the _Next Step_ you plan to take with grant support.
 1. You can complete this work within 3 months. 
 1. You agree to open-source this work, via MIT license for code or [CC-BY-SA 3.0](https://ipfs.io/ipfs/QmVreNvKsQmQZ83T86cWSjPu2vR3yZHGPm5jnxFuunEB9u) license for content.
@@ -30,7 +31,40 @@ Grant applications are typically reviewed every 2 weeks.
 
 [**Apply Here**](https://github.com/protocol/ipfs-grants/issues/new?assignees=parkan&labels=microgrant&template=microgrant.md&title=%5BMICROGRANT%5D+%3CYour+Title+Here%3E)
 
+## FAQ
+
+* Q: My project publishes data or files to IPFS, does it qualify?
+  * A: Yes
+
+* Q: My project uses OrbitDB, Textile, nft.storage, or other framework or service, not IPFS directly. Does it qualify?
+  * A: Yes
+
+* Q: My project saves data to, or retrieves data from the Filecoin network, does it qualify?
+  * A: Yes
+
+* Q: Do you pay out in other currencies besides FIL?
+  * A: No
+
+* Q: Should I send the payment information and W8/9 forms to you over email?
+  * A: No. We will reply to selected grantees with a form to submit that information.
+
+* Q: Which Filecoin wallet should I use?
+  * A: Any valid Filecoin address can be used. You can read more about Filecoin wallets [in the documentation](https://docs.filecoin.io/reference/#wallets). We are not responsible for any use of the FIL once the deposit has been made to the wallet address you provided.
+
+* Q: When is the Filecoin payment made, at what price, and will I be notified?
+  * A: Protocol Labs processes Filecoin payments twice monthly, and there is a short validation period for transactions. Typically you will not have to wait longer than three weeks once your application has been submitted. The Filecoin price at the end of the prior day is used to determine the amount; however, this may vary based on market conditions. You will receive an email notifying you that your deposit has been made.
+
+* Q: Can someone join the team who was not part of the original hackathon? Or can I switch with someone? Or can only a subset of the original team still participate?
+  * A: Yes! All team permutations are ok as long as there is only one submission per original hackathon project.
+
+* Q: I'm not a coding participant; I coordinated or made videos or helped in other ways. Am I eligible?
+  * A: YES! In real life, successful products are the result of many roles, skills, backgrounds and disciplines... not just coding. You are an INSTRUMENTAL part of your team, and are eligible to receive the grant as well.
+
+* Q: What if we don't finish the work and run off with the money?
+  * A: You will carry the weight of your actions for the rest of your days, and may be reborn in the next life as a hungry ghost.
+
 ## Support
 Support for Next Step Microgrants is contributed by [Protocol Labs](https://protocol.ai/) on a quarterly basis.
+
 
 _For more information on the IPFS project's overall grant program, including other grant types, check out the top level of the [IPFS Grant Platform repo](https://github.com/ipfs/devgrants)_

--- a/MICROGRANTS.md
+++ b/MICROGRANTS.md
@@ -1,39 +1,36 @@
-# Adoption Microgrants
-
-|:warning: The IPFS team are not funding any new proposals in this repo until Q1 2021. This platform is still open for discussing grants for future funding, to submit proposals that could be funded from other interested parties, or to propose funding of your own for projects you'd like to see exist!|
-|---|
+# Next Step Microgrants
 
 ## About
 
-The IPFS Adoption Microgrants are intended to encourage experimentation with, and adoption of IPFS across a range of fields. They are offered with the understanding that decentralized technologies are a rapidly developing field with many unknowns, and do not make complete technical success of the proposal a prerequisite for the award.
+IPFS Next Step Microgrants are available to support taking the _Next Step_ after building an initial prototype with IPFS. They are offered with the understanding that decentralized technologies are a rapidly developing field with many unknowns. Next Step Microgrants seek to match the pace, breadth, and experimental nature of this work.
 
-Microgrants aligned with this quarter's [Focus Area](FOCUS.md) will be given priority consideration.
+From time-to-time, we may announce a [focus area](FOCUS.md) (such as offline use, GIS, digital democracy, etc) for priority consideration. However, all submissions will always be reviewed.
 
 ### Intended Audience
-These grants are intended for independent developers, small studios, non-profits, activists, and researchers. The ideal candidate is a domain expert exploring integrating decentralized technologies into their work, particularly broadly used tools or frameworks. Open Source work is preferred, but exceptions can be made on a case-by-case basis.
-
-Additionally, each quarter we may announce a theme (such as offline use, GIS, digital democracy, etc). Projects in this field will be given first consideration.
+These grants are intended for independent developers, small studios, non-profits, activists, researchers... and you! 
 
 ### Award
-The grants are awarded in the amount of **$1000**. Approximately 10 grants are awarded every quarter.
+Next Step Microgrants are awarded in the amount of **$5,000**. The entire grant amount be used to support work related to integrating or improving IPFS, such as developer time, hosting services, relevant hardware such as a raspberry pi, etc. 
 
 ### Applying and Reporting
-The microgrants are intended to be easy to apply for, evaluate, and administer. The [application](../../issues/new?assignees=parkan&labels=microgrant&template=microgrant.md&title=%5BMICROGRANT%5D+%3CYour+Title+Here%3E) consists of a brief description of your current practice and the intended IPFS integration project, plus some biographical info.
+Next Step Microgrants are intended to be easy to apply for, evaluate, and administer. Projects must meet these 5 criteria:
 
-The principal condition of receiving the award is that the entire amount be used to support work related to integrating or improving IPFS, such as developer time, hosting services, relevant hardware such as a raspberry pi, etc. We may ask for documentation of how the money was spent. 
+1. You've already built something with IPFS (or closely related technologies such as IPLD, libp2p, etc.), independently or as part of a course or hackathon.
+1. You can provide a clear and straightforward description of the _Next Step_ you plan to take with grant support.
+1. You can complete this work within 1 month. 
+1. You agree to open-source this work, via MIT license for code or [CC-BY-SA 3.0](https://ipfs.io/ipfs/QmVreNvKsQmQZ83T86cWSjPu2vR3yZHGPm5jnxFuunEB9u) license for content.
+1. You agree to complete a grant report 1 month after award date, with the results of your microgrant-funded work, as well as a description of your experience building on IPFS, including any challenges or shortcomings encountered.
 
-One month after the grant is awarded, or once your project is complete (whichever comes first), you'll be asked to provide a report describing your experience building on IPFS, including details of any technical or documentation shortcomings encountered. If your project is successful, we may contact you about promoting the resulting work, including coverage on [the IPFS Blog](https://blog.ipfs.io/) or social media.
+We may also contact you about promoting the resulting work, including coverage on [the IPFS Blog](https://blog.ipfs.io/) or social media.
 
-
-### Cadence
-The grants are currently awarded on a rolling basis, though we may switch to fixed quarterly cohorts in the future.
+### Timelines
+Applications are reviewed every 2 weeks. The next 2 review dates are June 1 and June 15, 2021.
 
 ## Apply
 
 [**Apply Here**](https://github.com/protocol/ipfs-grants/issues/new?assignees=parkan&labels=microgrant&template=microgrant.md&title=%5BMICROGRANT%5D+%3CYour+Title+Here%3E)
 
 ## Support
-The grant fund is contributed by [Protocol Labs](https://protocol.ai/) on a quarterly basis.
+Support for Next Step Microgrants is contributed by [Protocol Labs](https://protocol.ai/) on a quarterly basis.
 
-## Note
-Adoption microgrants are just one aspect of the IPFS project's overall grant program. Check out the top level of the [IPFS Grant Platform repo](https://github.com/ipfs/devgrants) to see the big picture.
+_For more information on the IPFS project's overall grant program, including other grant types, check out the top level of the [IPFS Grant Platform repo](https://github.com/ipfs/devgrants)_

--- a/README.md
+++ b/README.md
@@ -1,40 +1,30 @@
 # ipfs-grants
 
-|:warning: The IPFS team are not funding any new proposals in this repo until Q1 2021. This platform is still open for discussing grants for future funding, to submit proposals that could be funded from other interested parties, or to propose funding of your own for projects you'd like to see exist!|
+| 📣 As of May 2021, several grant types have re-opened to applications. |
 |---|
 
-Welcome to the IPFS Grant Platform! The Grant Platform connects grant makers with builders and researchers in the IPFS community. Whether you represent a foundation that wants to move the space forward, a company looking to accelerate development on the features your application needs, or a dev team itching to hack on IPFS tools, you've come to the right place. Take a look at the supported grant types and available funding + work opportunities below.
+Welcome to the IPFS Grant Platform! The IPFS Grant Platform connects grant makers with builders and researchers in the IPFS community. Whether you represent a foundation that wants to move the space forward, a company looking to accelerate development on the features your application needs, or a dev team itching to hack on IPFS tools, you've come to the right place. Take a look at the supported grant types and available opportunities below.
 
 ## Grant Types
 
 ### Bounty
-The bounty challenges are simply issues in IPFS-related repos that have a monetary reward associated with them. You don't need to propose a solution or spec out the work for these challenges⁠—simply submit a patch addressing the issue and you can claim the bounty once the PR is merged.
-
-For a list of issues eligible for Bounties, award amounts, and more details see [BOUNTIES](BOUNTIES.md)
+Bounties are monetary awards for completing eligible issues in IPFS-related repos. To claim a bounty, simply submit a patch addressing the issue &mdash; no other proposal or pre-approval is required. Once the PR is merged, you can claim the bounty. You can also offer a bounty by following the steps in [Bounties: How to Propose](BOUNTIES.md#how-to-propose).
 
 [**LIST OF BOUNTIES**](../../projects/1) • [**CLAIM A BOUNTY**](BOUNTIES.md#how-to-collect) • [**START A BOUNTY**](BOUNTIES.md#how-to-propose) • [Read More](BOUNTIES.md)
 
 ---
 
-### RFP
+### Next Step Microgrants
+Grants of $5,000 are available to support taking the _next step_ after you have created an initial prototype with IPFS. These grants are intended for independent developers, small studios, non-profits, activists, and researchers. Applicants may be working independently, or as part of a course or hackathon.
 
-|⚠️ on hold until Q1 2021 ⚠️|
-|---|
+Acceptance criteria are very simple, and work is expected to be complete within 2 months. Adoption Microgrants are funded by Protocol Labs.
 
-Projects too large for a bounty are specified as RFPs and can range from more complex feature work on IPFS to entirely new tools and libraries. 
-
-To see open RFPs and learn more about the proposal process see [RFPs](rfps). RFPs may be funded by Protocol Labs, other community members, or a consortium of interested parties.
-
-[**See Available RFPs**](rfps) • [Read More](rfps)
+[**APPLY FOR A MICROGRANT**](MICROGRANTS.md#Apply) • [**See Microgrant Proposals**](../../issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Atype%3Amicrogrant+) • [Read More](MICROGRANTS.md)
 
 ---
 
 ### Open Grant
-
-|⚠️ on hold until Q1 2021 ⚠️|
-|---|
-
-Do you have an idea for pushing the IPFS ecosystem forward not already covered by an RFP? Propose an open grant for consideration by the IPFS community.
+Do you have an idea for pushing the IPFS ecosystem forward? Grants of up to $30,000 are available to support for novel ideas that advance the IPFS ecosystem, bring significant new usage, or directly advance the IPFS mission statemnent.
 
 To read more about creating an Open Grant proposal, see [OPEN GRANTS](open-grants).
 
@@ -42,23 +32,23 @@ To read more about creating an Open Grant proposal, see [OPEN GRANTS](open-grant
 
 ---
 
-### Adoption Microgrant
-
-|⚠️ on hold until Q1 2021 ⚠️|
-|---|
-
-These are small grants intended to help stimulate experimentation with and adoption of IPFS across a wide range of fields. The application and reporting requirements are more relaxed, but the monetary awards are more limited ($1k).
-
-To read more about Adoption Microgrants see [MICROGRANTS](MICROGRANTS.md). Adoption Microgrants are funded by Protocol Labs.
-
-[**APPLY FOR A MICROGRANT**](MICROGRANTS.md#Apply) • [**See Microgrant Proposals**](../../issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Atype%3Amicrogrant+) • [Read More](MICROGRANTS.md)
-
----
-
 ### Targeted Grant
 These are grants negotiated directly with a recipient, rather than going through the usual RFP/open grant process. Targeted Grants are currently made by Protocol Labs.
 
 [**See In-Progress Targeted Grants**](../../issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Atype%3Atargeted-grant) • [**See Completed Targeted Grants**](targeted-grants/completed)
+
+---
+
+### RFP
+
+|⚠️ on hold ⚠️|
+|---|
+
+Projects too large for a bounty are specified as RFPs and can range from more complex feature work on IPFS to entirely new tools and libraries. 
+
+To see open RFPs and learn more about the proposal process see [RFPs](rfps). RFPs may be funded by Protocol Labs, other community members, or a consortium of interested parties.
+
+[**See Available RFPs**](rfps) • [Read More](rfps)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Bounties are monetary awards for completing eligible issues in IPFS-related repo
 ---
 
 ### Next Step Microgrants
-Grants of $5,000 are available to support taking the _next step_ after you have created an initial prototype with IPFS. These grants are intended for independent developers, small studios, non-profits, activists, and researchers. Applicants may be working independently, or as part of a course or hackathon.
+Grants of $5,000 in FIL are available to support taking the _next step_ after you have created an initial prototype with IPFS. These grants are intended for independent developers, small studios, non-profits, activists, and researchers. Applicants may be working independently, or as part of a course or hackathon.
 
 Acceptance criteria are very simple, and work is expected to be complete within 2 months. Adoption Microgrants are funded by Protocol Labs.
 


### PR DESCRIPTION
This PR is intended to reopen IPFS grants, starting with the Next Step grants.

* Removes all "on pause" warnings, except for RFPs
* Renames Adoption Microgrants as Next Step Microgrants grants
  * Update related details & application flows